### PR TITLE
feat: add vscode launch.json target

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+    "configurations": [
+        {
+            "name": "mkdocs serve",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "mkdocs",
+            "args": ["serve"],
+            "cwd": "${workspaceFolder}/docs",
+        },
+    ]
+}


### PR DESCRIPTION
This PR adds a vscode launch config to sever the website. This is just a quality of life improvement so that I can launch the site with a shortcut instead of typing something.

Maybe it'd be better to do it with a task but I don't know how to launch those with a simple shortcut.